### PR TITLE
Switch FE to env vars

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_UPLOADS_URL=http://localhost:3001/uploads
+NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
+NEXT_PUBLIC_EMBEDDING_URL=http://localhost:8000
+NEXT_PUBLIC_REPORT_API_URL=http://localhost:5000

--- a/frontend/src/app/(main)/discover/page.js
+++ b/frontend/src/app/(main)/discover/page.js
@@ -56,8 +56,8 @@ const DiscoverPage = () => {
                 });
                 const queryString = params.toString();
                 const url = queryString
-                    ? `http://localhost:3001/api/ai/recommendations?${queryString}`
-                    : `http://localhost:3001/api/ai/recommendations`;
+                    ? `${process.env.NEXT_PUBLIC_API_URL}/api/ai/recommendations?${queryString}`
+                    : `${process.env.NEXT_PUBLIC_API_URL}/api/ai/recommendations`;
 
                 console.log("Fetching recommendations with URL:", url);
                 console.log("Auth token:", auth.access_token);
@@ -149,7 +149,7 @@ const DiscoverPage = () => {
     const handleMatch = async (userId, callback) => {
         try {
             const response = await axios.post(
-                "http://localhost:3001/api/match",
+                `${process.env.NEXT_PUBLIC_API_URL}/api/match`,
                 {
                     receiverId: userId,
                 },
@@ -196,7 +196,7 @@ const DiscoverPage = () => {
     const handleSelectProfile = async (profile) => {
         console.log("Selected profile:", profile.id);
         try {
-            const response = await axios.get(`http://localhost:3001/api/user/${profile.id}`, {
+            const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/user/${profile.id}`, {
                 headers: {
                     Authorization: `Bearer ${auth?.access_token}`,
                 },

--- a/frontend/src/app/(main)/matches/page.js
+++ b/frontend/src/app/(main)/matches/page.js
@@ -18,7 +18,7 @@ const Matches = () => {
       console.warn("Photo URL is missing", { photo });
       return "/default-avatar.jpg";
     }
-    return photo.startsWith("http") ? photo : `http://localhost:3001${photo.toLowerCase()}`;
+    return photo.startsWith("http") ? photo : `${process.env.NEXT_PUBLIC_API_URL}${photo.toLowerCase()}`;
   };
 
   useEffect(() => {
@@ -31,7 +31,7 @@ const Matches = () => {
         if (!auth?.access_token) {
           throw new Error("No access token available");
         }
-        const response = await fetch("http://localhost:3001/api/match", {
+        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/match`, {
           method: "GET",
           headers: {
             Authorization: `Bearer ${auth.access_token}`,

--- a/frontend/src/app/(main)/message/[matchId]/page.js
+++ b/frontend/src/app/(main)/message/[matchId]/page.js
@@ -53,7 +53,7 @@ const MessagePage = () => {
       setIsLoading(true);
       setError(null);
       const response = await fetch(
-        `http://localhost:3001/api/message/${id}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/message/${id}`,
         {
           headers: {
             "Content-Type": "application/json",
@@ -119,7 +119,7 @@ const MessagePage = () => {
     };
     console.log("Sending message:", JSON.stringify(newMessage, null, 2)); // Debug
     try {
-      const response = await fetch(`http://localhost:3001/api/message`, {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/message`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/src/app/(main)/notifications/page.js
+++ b/frontend/src/app/(main)/notifications/page.js
@@ -33,7 +33,7 @@ const getNotificationContent = (notification) => {
     }
 
     // Chuẩn hóa URL
-    return url.startsWith("http") ? url : `http://localhost:3001${url.toLowerCase()}`;
+    return url.startsWith("http") ? url : `${process.env.NEXT_PUBLIC_API_URL}${url.toLowerCase()}`;
   };
 
   const photoUrl = normalizePhotoUrl(notification?.user?.photo);
@@ -66,7 +66,7 @@ export default function NotificationsPage() {
 
   const fetchNotifications = async () => {
     try {
-      const res = await fetch("http://localhost:3001/api/notifications", {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/notifications`, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${auth?.auth?.access_token}`,
@@ -98,7 +98,7 @@ export default function NotificationsPage() {
     console.log("Accepted notification:");
     try {
       const res = await fetch(
-        `http://localhost:3001/api/match/${matchId}`,
+        `${process.env.NEXT_PUBLIC_API_URL}/api/match/${matchId}`,
         {
           method: "PUT",
           headers: {

--- a/frontend/src/app/(main)/page.js
+++ b/frontend/src/app/(main)/page.js
@@ -39,7 +39,7 @@ const Home = () => {
     }
     let cleanUrl = url.replace(/^\/*uploads\/*/i, "");
     cleanUrl = cleanUrl.startsWith("/") ? cleanUrl : `/${cleanUrl}`;
-    const finalUrl = `http://localhost:3001/uploads${cleanUrl.toLowerCase()}`;
+    const finalUrl = `${process.env.NEXT_PUBLIC_UPLOADS_URL}${cleanUrl.toLowerCase()}`;
     console.debug(`Normalized photo URL: ${finalUrl}`);
     return finalUrl;
   };
@@ -98,8 +98,8 @@ const Home = () => {
       params.append("limit", "100");
       const queryString = params.toString();
       const url = queryString
-        ? `http://localhost:3001/api/user/list-match?${queryString}`
-        : `http://localhost:3001/api/user/list-match`;
+        ? `${process.env.NEXT_PUBLIC_API_URL}/api/user/list-match?${queryString}`
+        : `${process.env.NEXT_PUBLIC_API_URL}/api/user/list-match`;
 
       console.log("Fetching profiles with URL:", url);
       console.log("Auth token:", auth.access_token);
@@ -216,7 +216,7 @@ const Home = () => {
   const handleMatch = async (userId, callback) => {
     try {
       const response = await axios.post(
-        "http://localhost:3001/api/match",
+        `${process.env.NEXT_PUBLIC_API_URL}/api/match`,
         {
           receiverId: userId,
         },

--- a/frontend/src/app/(main)/profile/page.js
+++ b/frontend/src/app/(main)/profile/page.js
@@ -49,13 +49,13 @@ const Profile = () => {
                 ?.filter((photo) => !photo.url.startsWith("https://avatars.githubusercontent.com"))
                 .map((photo) => ({
                     id: photo.id,
-                    url: photo.url.startsWith("http") ? photo.url : `http://localhost:3001${photo.url.toLowerCase()}`,
+                    url: photo.url.startsWith("http") ? photo.url : `${process.env.NEXT_PUBLIC_API_URL}${photo.url.toLowerCase()}`,
                     is_profile_pic: photo.is_profile_pic,
                 })) || [],
             profilePhoto: currentUser?.photos?.find((photo) => photo.is_profile_pic)?.url
                 ? currentUser.photos.find((photo) => photo.is_profile_pic).url.startsWith("http")
                     ? currentUser.photos.find((photo) => photo.is_profile_pic).url
-                    : `http://localhost:3001${currentUser.photos.find((photo) => photo.is_profile_pic).url.toLowerCase()}`
+                    : `${process.env.NEXT_PUBLIC_API_URL}${currentUser.photos.find((photo) => photo.is_profile_pic).url.toLowerCase()}`
                 : "/default-avatar.jpg",
         };
     }, [currentUser, metadata]);
@@ -288,7 +288,7 @@ const EditBioModal = ({ bio, onSave, onClose }) => {
         setLoading(true);
         try {
             await axios.put(
-                "http://localhost:3001/api/user/update-profile",
+                `${process.env.NEXT_PUBLIC_API_URL}/api/user/update-profile`,
                 {
                     user: {
                         id: currentUser.id,
@@ -369,7 +369,7 @@ const EditInterestsModal = ({ interests, onSave, onClose }) => {
                 .filter((id) => id !== undefined);
 
             await axios.put(
-                "http://localhost:3001/api/user/update-profile",
+                `${process.env.NEXT_PUBLIC_API_URL}/api/user/update-profile`,
                 {
                     user: {
                         id: currentUser.id,
@@ -459,7 +459,7 @@ const EditPhotosModal = ({ photos, onSave, onClose }) => {
                 formData.append("bioId", currentUser?.bioId);
 
                 const response = await axios.post(
-                    "http://localhost:3001/api/upload/single",
+                    `${process.env.NEXT_PUBLIC_API_URL}/api/upload/single`,
                     formData,
                     {
                         headers: {
@@ -476,7 +476,7 @@ const EditPhotosModal = ({ photos, onSave, onClose }) => {
                         id: newPhoto.id,
                         url: newPhoto.url.startsWith("http")
                             ? newPhoto.url
-                            : `http://localhost:3001${newPhoto.url.toLowerCase()}`,
+                            : `${process.env.NEXT_PUBLIC_API_URL}${newPhoto.url.toLowerCase()}`,
                         is_profile_pic: newPhoto.is_profile_pic,
                     },
                 ]);
@@ -500,7 +500,7 @@ const EditPhotosModal = ({ photos, onSave, onClose }) => {
 
         setLoading(true);
         try {
-            await axios.delete(`http://localhost:3001/api/upload/${photoToRemove.id}`, {
+            await axios.delete(`${process.env.NEXT_PUBLIC_API_URL}/api/upload/${photoToRemove.id}`, {
                 headers: {
                     Authorization: `Bearer ${auth?.access_token}`,
                 },
@@ -526,7 +526,7 @@ const EditPhotosModal = ({ photos, onSave, onClose }) => {
         try {
             if (currentPhotos.length > 0) {
                 await axios.put(
-                    "http://localhost:3001/api/user/update-profile",
+                    `${process.env.NEXT_PUBLIC_API_URL}/api/user/update-profile`,
                     {
                         user: {
                             id: currentUser.id,
@@ -549,7 +549,7 @@ const EditPhotosModal = ({ photos, onSave, onClose }) => {
             } else {
                 // Nếu không còn ảnh, gửi danh sách rỗng
                 await axios.put(
-                    "http://localhost:3001/api/user/update-profile",
+                    `${process.env.NEXT_PUBLIC_API_URL}/api/user/update-profile`,
                     {
                         user: {
                             id: currentUser.id,
@@ -666,7 +666,7 @@ const EditProfilePhotoModal = ({ currentPhoto, onSave, onClose }) => {
                 formData.append("isProfilePic", "true");
 
                 const response = await axios.post(
-                    "http://localhost:3001/api/upload/single",
+                    `${process.env.NEXT_PUBLIC_API_URL}/api/upload/single`,
                     formData,
                     {
                         headers: {
@@ -679,7 +679,7 @@ const EditProfilePhotoModal = ({ currentPhoto, onSave, onClose }) => {
                 const newPhoto = response.data.photo;
                 const newPhotoUrl = newPhoto.url.startsWith("http")
                     ? newPhoto.url
-                    : `http://localhost:3001${newPhoto.url.toLowerCase()}`;
+                    : `${process.env.NEXT_PUBLIC_API_URL}${newPhoto.url.toLowerCase()}`;
 
                 // Cập nhật state với ảnh đại diện mới và danh sách ảnh
                 onSave({
@@ -689,7 +689,7 @@ const EditProfilePhotoModal = ({ currentPhoto, onSave, onClose }) => {
                             .filter((photo) => photo.id !== newPhoto.id)
                             .map((photo) => ({
                                 id: photo.id,
-                                url: photo.url.startsWith("http") ? photo.url : `http://localhost:3001${photo.url.toLowerCase()}`,
+                                url: photo.url.startsWith("http") ? photo.url : `${process.env.NEXT_PUBLIC_API_URL}${photo.url.toLowerCase()}`,
                                 is_profile_pic: false,
                             })),
                         {

--- a/frontend/src/app/(main)/settings/page.js
+++ b/frontend/src/app/(main)/settings/page.js
@@ -54,7 +54,7 @@ const Settings = () => {
     }
 
     // Chuẩn hóa URL
-    return url.startsWith("http") ? url : `http://localhost:3001${url.toLowerCase()}`;
+    return url.startsWith("http") ? url : `${process.env.NEXT_PUBLIC_API_URL}${url.toLowerCase()}`;
   };
 
   useEffect(() => {
@@ -269,7 +269,7 @@ const PhotoUploadModal = ({ currentPhoto, onSave, onClose }) => {
       console.warn("Invalid or missing photo URL", { photo });
       return "/default-avatar.jpg";
     }
-    return photo.startsWith("http") ? photo : `http://localhost:3001${photo.toLowerCase()}`;
+    return photo.startsWith("http") ? photo : `${process.env.NEXT_PUBLIC_API_URL}${photo.toLowerCase()}`;
   };
 
   const handlePhotoUpload = async (file) => {

--- a/frontend/src/app/auth/otp/OTPVerification.jsx
+++ b/frontend/src/app/auth/otp/OTPVerification.jsx
@@ -65,7 +65,7 @@ const OTPVerification = ({ email, onVerify, onResend, onBack }) => {
         setLoading(true);
         setError("");
         try {
-            const response = await axios.post("http://localhost:3001/api/auth/verify-otp", {
+            const response = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/verify-otp`, {
                 email,
                 otp: otpString,
             });

--- a/frontend/src/app/auth/register/page.js
+++ b/frontend/src/app/auth/register/page.js
@@ -46,7 +46,7 @@ export default function Register() {
         }
 
         try {
-            const res = await fetch("http://localhost:3001/api/auth/register", {
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/register`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -73,7 +73,7 @@ export default function Register() {
 
     const handleVerifyOTP = async (otp) => {
         try {
-            const res = await fetch("http://localhost:3001/api/auth/verify-otp", {
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/verify-otp`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -97,7 +97,7 @@ export default function Register() {
 
     const handleResendOTP = async () => {
         try {
-            const res = await fetch("http://localhost:3001/api/auth/send-verification-otp", {
+            const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/send-verification-otp`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/frontend/src/app/dashboard/page.js
+++ b/frontend/src/app/dashboard/page.js
@@ -74,7 +74,7 @@ export default function Dashboard() {
                 return;
             }
             try {
-                const res = await axios.get("http://localhost:3001/api/me", {
+                const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/me`, {
                     headers: {
                         "Content-Type": "application/json",
                         Authorization: `Bearer ${token}`,
@@ -87,7 +87,7 @@ export default function Dashboard() {
                 }
                 const getUsersOnline = async () => {
                     const res = await axios.get(
-                        "http://localhost:3001/api/users/online",
+                        `${process.env.NEXT_PUBLIC_API_URL}/api/users/online`,
                         {
                             headers: {
                                 "Content-Type": "application/json",
@@ -302,3 +302,4 @@ export default function Dashboard() {
         </main>
     );
 }
+

--- a/frontend/src/app/profile-setup/components/PhotoUpload.js
+++ b/frontend/src/app/profile-setup/components/PhotoUpload.js
@@ -46,7 +46,7 @@ const PhotoUpload = ({ formData, setFormData }) => {
       return URL.createObjectURL(photo);
     }
     if (typeof photo === "string") {
-      return photo.startsWith("http") ? photo : `http://localhost:3001${photo.toLowerCase()}`;
+      return photo.startsWith("http") ? photo : `${process.env.NEXT_PUBLIC_API_URL}${photo.toLowerCase()}`;
     }
     return photoBase64 || "/default-avatar.jpg";
   };

--- a/frontend/src/app/profile-setup/components/ProfileSetup.js
+++ b/frontend/src/app/profile-setup/components/ProfileSetup.js
@@ -265,7 +265,7 @@ const ProfileSetup = () => {
                     try {
                         const postPhotos = await retryRequest(() =>
                             axios.post(
-                                "http://localhost:3001/api/upload/multiple",
+                                `${process.env.NEXT_PUBLIC_API_URL}/api/upload/multiple`,
                                 formDataUpload,
                                 {
                                     headers: {
@@ -302,7 +302,7 @@ const ProfileSetup = () => {
             try {
                 const res = await retryRequest(() =>
                     axios.put(
-                        "http://localhost:3001/api/user/update-profile",
+                        `${process.env.NEXT_PUBLIC_API_URL}/api/user/update-profile`,
                         result,
                         {
                             headers: {

--- a/frontend/src/app/report/page.js
+++ b/frontend/src/app/report/page.js
@@ -21,7 +21,7 @@ export default function ReportPage() {
 
     setLoading(true);
     try {
-      const res = await fetch("http://localhost:5000/api/reports", {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_REPORT_API_URL}/api/reports`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -96,3 +96,4 @@ export default function ReportPage() {
     </main>
   );
 }
+

--- a/frontend/src/components/ChatWindow.jsx
+++ b/frontend/src/components/ChatWindow.jsx
@@ -46,7 +46,7 @@ export default function ChatWindow({ matchId, user }) {
             }
             try {
                 const res = await axios.get(
-                    `http://localhost:3001/api/rooms/${matchId}`,
+                    `${process.env.NEXT_PUBLIC_API_URL}/api/rooms/${matchId}`,
                     {
                         headers: {
                             "Content-Type": "application/json",
@@ -74,7 +74,7 @@ export default function ChatWindow({ matchId, user }) {
                     return;
                 }
                 const res = await axios(
-                    `http://localhost:3001/api/messages?match_id=${matchId}`
+                    `${process.env.NEXT_PUBLIC_API_URL}/api/messages?match_id=${matchId}`
                 );
                 setMessages(res.data);
             } catch (err) {
@@ -213,3 +213,4 @@ export default function ChatWindow({ matchId, user }) {
         </div>
     );
 }
+

--- a/frontend/src/components/cards/ProfileDetail.js
+++ b/frontend/src/components/cards/ProfileDetail.js
@@ -20,14 +20,14 @@ const ProfileDetail = ({ profile: initialProfile, onBack }) => {
         // Loại bỏ /uploads lặp lại và chuẩn hóa đường dẫn
         let cleanUrl = url.replace(/^\/*uploads\/*/i, "");
         cleanUrl = cleanUrl.startsWith("/") ? cleanUrl : `/${cleanUrl}`;
-        const finalUrl = `http://localhost:3001/uploads${cleanUrl.toLowerCase()}`;
+        const finalUrl = `${process.env.NEXT_PUBLIC_UPLOADS_URL}${cleanUrl.toLowerCase()}`;
         console.debug(`Normalized photo URL: ${finalUrl}`);
         return finalUrl;
     };
 
     // Kiểm tra xem URL có phải từ localhost:3001 không
     const isLocalImage = (url) => {
-        return url && url.startsWith("http://localhost:3001");
+        return url && url.startsWith(process.env.NEXT_PUBLIC_API_URL);
     };
 
     // Chuẩn hóa profile để đảm bảo URL ảnh đúng

--- a/frontend/src/context/ProfileContext.js
+++ b/frontend/src/context/ProfileContext.js
@@ -14,7 +14,7 @@ export function ProfileProvider({ children }) {
         // const fetchProfileSetupData = async () => {
         //     try {
         //         console.log("Calling /api/profile-setup...");
-        //         const response = await axios.get("http://localhost:3001/api/profile-setup");
+        //         const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/profile-setup`);
         //         console.log("Profile setup response:", JSON.stringify(response.data, null, 2));
         //         setProfileSetupData(response.data.data);
         //     } catch (error) {

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -9,8 +9,8 @@ import * as authHelper from "./_helper";
 setupAxios(axios);
 const AuthContext = createContext(null);
 
-const LOGIN_URL = "http://localhost:3001/api/auth/login";
-const GET_USER_URL = "http://localhost:3001/api/user/me";
+const LOGIN_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`;
+const GET_USER_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/user/me`;
 
 export function AuthProvider({ children }) {
   const router = useRouter();

--- a/frontend/src/hooks/useMetadata.js
+++ b/frontend/src/hooks/useMetadata.js
@@ -20,7 +20,7 @@ export function MetadataProvider({ children }) {
         try {
             const token = auth?.access_token;
             console.log("Fetching metadata with token:", token ? token.slice(0, 20) + "..." : "No token");
-            const res = await axios.get("http://localhost:3001/api/metadata", {
+            const res = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/metadata`, {
                 headers: token ? { Authorization: `Bearer ${token}` } : {},
             });
             console.log("Metadata response:", JSON.stringify(res.data, null, 2));

--- a/frontend/src/hooks/useRecommendations.js
+++ b/frontend/src/hooks/useRecommendations.js
@@ -14,7 +14,7 @@ export function useRecommendations() {
     const fetchRecommendations = async () => {
       setIsLoading(true);
       try {
-        const response = await axios.get('http://localhost:3001/api/recommendations', {
+        const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/recommendations`, {
           headers: {
             Authorization: `Bearer ${auth?.access_token}`,
           },

--- a/frontend/src/hooks/useSocket.js
+++ b/frontend/src/hooks/useSocket.js
@@ -12,7 +12,7 @@ export const SocketProvider = ({ children }) => {
 
     useEffect(() => {
         if (!currentUser) return;
-        const newSocket = io("http://localhost:3001", {
+        const newSocket = io(process.env.NEXT_PUBLIC_SOCKET_URL, {
             autoConnect: false,
             reconnection: true,
         });
@@ -40,3 +40,4 @@ export const useSocket = () => {
     // }
     return context;
 };
+

--- a/frontend/src/lib/config.js
+++ b/frontend/src/lib/config.js
@@ -1,0 +1,5 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+export const UPLOADS_URL = process.env.NEXT_PUBLIC_UPLOADS_URL || 'http://localhost:3001/uploads';
+export const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+export const EMBEDDING_URL = process.env.NEXT_PUBLIC_EMBEDDING_URL || 'http://localhost:8000';
+export const REPORT_API_URL = process.env.NEXT_PUBLIC_REPORT_API_URL || 'http://localhost:5000';

--- a/frontend/src/lib/socket.js
+++ b/frontend/src/lib/socket.js
@@ -4,7 +4,7 @@ let socket;
 
 export const getSocket = () => {
     if (!socket) {
-        socket = io("http://localhost:3001", {
+        socket = io(process.env.NEXT_PUBLIC_SOCKET_URL, {
             autoConnect: true,
             reconnection: true,
         });
@@ -18,3 +18,4 @@ export const disconnectSocket = () => {
         socket = null;
     }
 };
+

--- a/frontend/src/redux/feature/authSlice.js
+++ b/frontend/src/redux/feature/authSlice.js
@@ -12,7 +12,7 @@ export const loginUser = createAsyncThunk(
     async (credentials, { rejectWithValue }) => {
         try {
             const response = await fetch(
-                "http://localhost:3001/api/auth/login",
+                `${process.env.NEXT_PUBLIC_API_URL}/api/auth/login`,
                 {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -35,7 +35,7 @@ export const registerUser = createAsyncThunk(
     async (userData, { rejectWithValue }) => {
         try {
             const response = await fetch(
-                "http://localhost:3001/api/auth/register",
+                `${process.env.NEXT_PUBLIC_API_URL}/api/auth/register`,
                 {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -103,3 +103,4 @@ const authSlice = createSlice({
 
 export const { logout, setCredentials } = authSlice.actions;
 export default authSlice.reducer;
+

--- a/frontend/src/ui/MatchModal.js
+++ b/frontend/src/ui/MatchModal.js
@@ -54,7 +54,7 @@ const MatchModal = ({ me, profile, onClose }) => {
                                     <img
                                         src={
                                             meAvatar?.url?.[0] === "/"
-                                                ? `http://localhost:3001${meAvatar?.url}`
+                                                ? `${process.env.NEXT_PUBLIC_API_URL}${meAvatar?.url}`
                                                 : "https://cdn.kona-blue.com/upload/kona-blue_com/post/images/2024/09/19/465/avatar-trang-1.jpg"
                                         }
                                         alt="Your profile"
@@ -71,7 +71,7 @@ const MatchModal = ({ me, profile, onClose }) => {
                                     <img
                                         src={
                                             youAvatar?.url?.[0] === "/"
-                                                ? `http://localhost:3001${youAvatar?.url}`
+                                                ? `${process.env.NEXT_PUBLIC_API_URL}${youAvatar?.url}`
                                                 : "https://cdn.kona-blue.com/upload/kona-blue_com/post/images/2024/09/19/465/avatar-trang-1.jpg"
                                         }
                                         alt={profile?.name}
@@ -105,3 +105,4 @@ const MatchModal = ({ me, profile, onClose }) => {
     );
 };
 export default MatchModal;
+

--- a/frontend/src/ui/NotificationDropdown.js
+++ b/frontend/src/ui/NotificationDropdown.js
@@ -31,7 +31,7 @@ const getNotificationContent = (notification) => {
     }
 
     // Chuẩn hóa URL
-    return url.startsWith("http") ? url : `http://localhost:3001${url.toLowerCase()}`;
+    return url.startsWith("http") ? url : `${process.env.NEXT_PUBLIC_API_URL}${url.toLowerCase()}`;
   };
 
   const photoUrl = normalizePhotoUrl(notification?.user?.photo);
@@ -63,7 +63,7 @@ const NotificationDropdown = ({ onClose }) => {
 
   const fetchNotifications = async () => {
     try {
-      const res = await fetch("http://localhost:3001/api/notifications", {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/notifications`, {
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${auth?.auth?.access_token}`,

--- a/frontend/src/utils/ImageUtils.js
+++ b/frontend/src/utils/ImageUtils.js
@@ -8,7 +8,7 @@ export const normalizePhotoUrl = (url) => {
   }
   let cleanUrl = url.replace(/^\/*uploads\/*/i, "");
   cleanUrl = cleanUrl.startsWith("/") ? cleanUrl : `/${cleanUrl}`;
-  const finalUrl = `http://localhost:3001/uploads${cleanUrl.toLowerCase()}`;
+  const finalUrl = `${process.env.NEXT_PUBLIC_UPLOADS_URL}${cleanUrl.toLowerCase()}`;
   console.debug(`Normalized photo URL: ${finalUrl}`);
   return finalUrl;
 };


### PR DESCRIPTION
## Summary
- add `.env` with public API endpoints
- add `config.js` to expose API URLs from environment
- replace hardcoded backend URLs with env variables across frontend

## Testing
- `pnpm lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853fa3b3364832b804903f54bc09f90